### PR TITLE
Add exec to nodejs call

### DIFF
--- a/etherpad-lite/Dockerfile
+++ b/etherpad-lite/Dockerfile
@@ -20,6 +20,8 @@ WORKDIR etherpad-lite
 RUN bin/installDeps.sh && rm settings.json
 COPY entrypoint.sh /entrypoint.sh
 
+RUN sed -i 's/^node/exec\ node/' bin/run.sh
+
 VOLUME /opt/etherpad-lite/var
 RUN ln -s var/settings.json settings.json
 


### PR DESCRIPTION
This patch add an "exec" call before running node, in order to have a cleaner (and faster) "stop" for the etherpad-lite containers.
This allow the node process to take PID 1 in docker container, and be able to receive the stop (SIGTERM) or kill (SIGKILL/whatever signal) command and stop gracefuly.
Without it, a docker stop (or restart) or docker kill command will send signal to the bash process running the bin/run.sh script, and it will not be forwarded to the node process, so after 10 seconds (in case of stop) docker will send a KILL signal to bash, and the node process will be destroyed.
