### PR TITLE
Add Docker secrets support

### DIFF
--- a/etherpad-lite/README.md
+++ b/etherpad-lite/README.md
@@ -67,6 +67,8 @@ to the mysql container.
 * `ETHERPAD_DB_PASSWORD`: MySQL password to use, mandatory. If legacy links
 are used and ETHERPAD_DB_USER is root, then `MYSQL_ENV_MYSQL_ROOT_PASSWORD` is
 automatically used.
+* `ETHERPAD_DB_PASSWORD_FILE`: MySQL password to use, replace `ETHERPAD_DB_PASSWORD`
+when using [Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 * `ETHERPAD_DB_NAME`: The mysql database to use. Defaults to *etherpad*. If the
 database is not available, it will be created when the container is launched.
 

--- a/etherpad-lite/entrypoint.sh
+++ b/etherpad-lite/entrypoint.sh
@@ -13,11 +13,15 @@ if [ "$ETHERPAD_DB_USER" = 'root' ]; then
 	: ${ETHERPAD_DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
 fi
 
+if [ -n "$ETHERPAD_DB_PASSWORD_FILE" ]; then
+	: ${ETHERPAD_DB_PASSWORD:=$(cat $ETHERPAD_DB_PASSWORD_FILE)}
+fi
+
 if [ -z "$ETHERPAD_DB_PASSWORD" ]; then
 	echo >&2 'error: missing required ETHERPAD_DB_PASSWORD environment variable'
 	echo >&2 '  Did you forget to -e ETHERPAD_DB_PASSWORD=... ?'
 	echo >&2
-	echo >&2 '  (Also of interest might be ETHERPAD_DB_USER and ETHERPAD_DB_NAME.)'
+	echo >&2 '  (Also of interest might be ETHERPAD_DB_PASSWORD_FILE, ETHERPAD_DB_USER and ETHERPAD_DB_NAME.)'
 	exit 1
 fi
 


### PR DESCRIPTION
Users can run the image with "-e ETHERPAD_DB_PASSWORD_FILE=/run/secrets/my_password"

example (compose v3.1 syntaxe):

```yaml
services:
  etherpad:
    image: tvelocity/etherpad-lite:latest
    networks:
      - etherpad
    environment:
      ETHERPAD_DB_HOST: "mysql"
      ETHERPAD_DB_PASSWORD_FILE: "/run/secrets/mysql_root_password"
    secrets:
      - mysql_root_password

secrets:
  secrets:
    mysql_root_password:
      external: true
```