### PR TITLE
[fixes #24] allow configuration of the API key via environment variable

### DIFF
--- a/etherpad-lite/README.md
+++ b/etherpad-lite/README.md
@@ -72,6 +72,7 @@ database is not available, it will be created when the container is launched
 (only if the database type is either `mysql` or `postgres`, and the user need to
 have the right to create the database).
 * `ETHERPAD_DB_CHARSET`: The charset to use. Defaults to *utf8mb4*.
+* `ETHERPAD_API_KEY`: if file `APIKEY.txt` is missing, the variable value is used to provision it
 
 The generated settings.json file will be available as a volume under
 */opt/etherpad-lite/var/*.

--- a/etherpad-lite/entrypoint.sh
+++ b/etherpad-lite/entrypoint.sh
@@ -56,6 +56,11 @@ if [ "$ETHERPAD_DB_TYPE" == 'postgres' ]; then
 	fi
 fi
 
+if [ ! -f APIKEY.txt ] && [ ! -z "${ETHERPAD_API_KEY}" ] ; then
+    echo "Creating APIKEY.txt as ETHERPAD_API_KEY is defined";
+    echo "${ETHERPAD_API_KEY}" > APIKEY.txt
+fi
+
 if [ ! -f settings.json ]; then
 
 	cat <<- EOF > settings.json


### PR DESCRIPTION
If file APIKEY.txt is missing, but variable ETHERPAD_API_KEY is non-empty, it's value is used to provision the file.  

(otherwise, etherpad application provisions the non-existing file with random string, unless it is externally mounted).