### PR TITLE
Support running as non-root

### DIFF
--- a/etherpad-lite/Dockerfile
+++ b/etherpad-lite/Dockerfile
@@ -22,6 +22,8 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN sed -i 's/^node/exec\ node/' bin/run.sh
 
+RUN chmod o+rwX -R .
+
 VOLUME /opt/etherpad-lite/var
 RUN ln -s var/settings.json settings.json
 

--- a/etherpad-lite/Dockerfile
+++ b/etherpad-lite/Dockerfile
@@ -22,7 +22,7 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN sed -i 's/^node/exec\ node/' bin/run.sh
 
-RUN chmod o+rwX -R .
+RUN chmod g+rwX,o+rwX -R .
 
 VOLUME /opt/etherpad-lite/var
 RUN ln -s var/settings.json settings.json


### PR DESCRIPTION
This change makes the etherpad-lite files world writable to support running as non-root, e.g. on OpenShift.

IMHO this does not worsen security as root can write anywhere in any case and as non-root etherpad can write its own files, the same as before when running the container as root.