### PR TITLE
Quote $ETHERPAD_ADMIN_PASSWORD

### DIFF
--- a/etherpad-lite/entrypoint.sh
+++ b/etherpad-lite/entrypoint.sh
@@ -73,7 +73,7 @@ if [ ! -f settings.json ]; then
 			  },
 	EOF
 
-	if [ $ETHERPAD_ADMIN_PASSWORD ]; then
+	if [ -n "$ETHERPAD_ADMIN_PASSWORD" ]; then
 
 		: ${ETHERPAD_ADMIN_USER:=admin}
 


### PR DESCRIPTION
I have an admin password containing `$`, e.g. `foo$bar` . This causes docker-compose to log `The bar variable is not set. Defaulting to a blank string.`