### PR TITLE
Adding wait-for-it

### DIFF
--- a/etherpad-lite/Dockerfile
+++ b/etherpad-lite/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Tony Motakis <tvelocity@gmail.com>
 ENV ETHERPAD_VERSION 1.6.1
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip nodejs-legacy npm mysql-client node-pg postgresql-client && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip nodejs-legacy npm mysql-client node-pg postgresql-client && wait-for-it \
     rm -r /var/lib/apt/lists/*
 
 WORKDIR /opt/

--- a/etherpad-lite/entrypoint.sh
+++ b/etherpad-lite/entrypoint.sh
@@ -31,6 +31,9 @@ fi
 : ${ETHERPAD_TITLE:=Etherpad}
 : ${ETHERPAD_PORT:=9001}
 
+# Wait for the database to come up. Right now, we don't timeout if this fails
+wait-for-it --quiet --host={ETHERPAD_DB_HOST} --port=${ETHERPAD_DB_PORT}
+
 # Check if database already exists
 if [ "$ETHERPAD_DB_TYPE" == 'mysql' ]; then
 	RESULT=`mysql -u${ETHERPAD_DB_USER} -p${ETHERPAD_DB_PASSWORD} --port=${ETHERPAD_DB_PORT} \

--- a/etherpad-lite/entrypoint.sh
+++ b/etherpad-lite/entrypoint.sh
@@ -31,6 +31,9 @@ fi
 : ${ETHERPAD_TITLE:=Etherpad}
 : ${ETHERPAD_PORT:=9001}
 
+# Wait for the database to come up. Right now, we don't timeout if this fails
+wait-for-it --quiet --host=${ETHERPAD_DB_HOST} --port=${ETHERPAD_DB_PORT}
+
 # Check if database already exists
 if [ "$ETHERPAD_DB_TYPE" == 'mysql' ]; then
 	RESULT=`mysql -u${ETHERPAD_DB_USER} -p${ETHERPAD_DB_PASSWORD} --port=${ETHERPAD_DB_PORT} \


### PR DESCRIPTION
Currently, the database (mysql or mariadb) may not start until after etherpad is already trying to start, in which case the etherpad instance fails to connect to the database, and exits immediately.

I've added `wait-for-it` to the entrypoint. It checks the database to see if the port is ready for connection. Once it is, the script proceeds as before.