### PR TITLE
Fix npm error, add compose

### DIFF
--- a/etherpad-lite/Dockerfile
+++ b/etherpad-lite/Dockerfile
@@ -5,7 +5,9 @@ MAINTAINER Tony Motakis <tvelocity@gmail.com>
 ENV ETHERPAD_VERSION 1.6.5
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip nodejs-legacy npm mysql-client node-pg postgresql-client && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip mysql-client postgresql-client && \
+    curl -sL https://deb.nodesource.com/setup_9.x | bash - && \
+    apt-get install -y nodejs node-pg && \
     rm -r /var/lib/apt/lists/*
 
 WORKDIR /opt/

--- a/etherpad-lite/README.md
+++ b/etherpad-lite/README.md
@@ -24,22 +24,9 @@ You don't need to set up a server and install Etherpad in order to use it. Just 
 
 ## Quickstart
 
-First you need a running mysql container, for example:
-
+Just run the docker-compose file to create a mysql-container and connect the etherpad container to it:
 ```bash
-$ docker network create ep_network
-$ docker run -d --network ep_network -e MYSQL_ROOT_PASSWORD=password --name ep_mysql mysql
-```
-
-Finally you can start an instance of Etherpad Lite:
-
-```bash
-$ docker run -d \
-    --network ep_network \
-    -e ETHERPAD_DB_HOST=ep_mysql \
-    -e ETHERPAD_DB_PASSWORD=password \
-    -p 9001:9001 \
-    tvelocity/etherpad-lite
+$ docker-compose up -d
 ```
 
 Etherpad will automatically create an `etherpad` database in the specified mysql

--- a/etherpad-lite/README.md
+++ b/etherpad-lite/README.md
@@ -24,7 +24,31 @@ You don't need to set up a server and install Etherpad in order to use it. Just 
 
 ## Quickstart
 
-Just run the docker-compose file to create a mysql-container and connect the etherpad container to it:
+Save this as `docker-compose.yml`:
+```
+version: '3.3'
+services:
+  pad:
+#    build: .
+    image: tvelocity/etherpad-lite
+    restart: always
+    ports:
+      - 9001:9001
+#    volumes:
+#      - /docker/etherpad/main:/opt/etherpad-lite/var
+    environment:
+      - ETHERPAD_DB_PASSWORD=changeme
+      - NODE_ENV=production
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=changeme
+#    volumes:
+#      - /docker/etherpad/mysql-dir:/var/lib/mysql
+```
+
+Run the docker-compose file to create a mysql-container and connect the etherpad container to it:
 ```bash
 $ docker-compose up -d
 ```

--- a/etherpad-lite/docker-compose.yml
+++ b/etherpad-lite/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.3'
+services:
+  pad:
+#    build: .
+    image: tvelocity/etherpad-lite
+    restart: always
+    ports:
+      - 9001:9001
+#    volumes:
+#      - /docker/etherpad/main:/opt/etherpad-lite/var
+    environment:
+      - ETHERPAD_DB_PASSWORD=changeme
+      - NODE_ENV=production
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=changeme
+#    volumes:
+#      - /docker/etherpad/mysql-dir:/var/lib/mysql


### PR DESCRIPTION
This fixes issue #35 and makes a quick deployment easier by providing a docker-compose.yml. The instructions to add the node repository come from here https://github.com/ether/etherpad-lite#installation. However I didn't try the postgres support. If you replace the `image: tvelocity/etherpad-lite` line with `build: . ` you can quickly test the Dockerfile without using the image from docker hub.